### PR TITLE
Add Travis CI badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # slcon-mentor
+[![Build Status](https://travis-ci.org/AndelaOSP/slcon-mentor.svg?branch=master)](https://travis-ci.org/AndelaOSP/slcon-mentor)
+
 SLcon Mentorship Platform for software engineers and IT professionals. This platform seeks to connect brilliant talents in the _Silicon Savannah_ with each other &mdash; and also connect them with other talented people around the world through a mentorship programme.
 
 This is a project for _developers_ by _developers_. Everyone is welcome to make their contribution.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # slcon-mentor
-[![Build Status](https://travis-ci.org/AndelaOSP/slcon-mentor.svg?branch=master)](https://travis-ci.org/AndelaOSP/slcon-mentor)
+[![Build Status](https://travis-ci.org/AndelaOSP/slcon-mentor.svg?branch=develop)](https://travis-ci.org/AndelaOSP/slcon-mentor)
 
 SLcon Mentorship Platform for software engineers and IT professionals. This platform seeks to connect brilliant talents in the _Silicon Savannah_ with each other &mdash; and also connect them with other talented people around the world through a mentorship programme.
 


### PR DESCRIPTION
I've added the badge for the branch develop. There seems to be an error in the build.

Side note:
The Travis CI page gave me the link for the branch 'master', which apparently doesn't exist.

Thanks for your support.